### PR TITLE
Free the memory of the reference genome

### DIFF
--- a/source/Genome.cpp
+++ b/source/Genome.cpp
@@ -32,12 +32,13 @@ Genome::Genome (Parameters &Pin ): pGe(Pin.pGe), sharedMemory(NULL), P(Pin), shm
     sjdbLength = pGe.sjdbOverhang==0 ? 0 : pGe.sjdbOverhang*2+1;
 };
 
-// Genome::~Genome()
-// {
-//     if (sharedMemory != NULL)
-//         delete sharedMemory;
-//     sharedMemory = NULL;
-// }
+Genome::~Genome()
+{
+    freeMemory();
+    if (sharedMemory != NULL)
+        delete sharedMemory;
+    sharedMemory = NULL;
+}
 
 void Genome::freeMemory(){//free big chunks of memory used by genome and suffix array
 

--- a/source/Genome.h
+++ b/source/Genome.h
@@ -48,7 +48,7 @@ class Genome {
         SharedMemory * sharedMemory;
 
         Genome (Parameters &Pin );
-        //~Genome();
+        ~Genome();
 
         void freeMemory();
         void genomeLoad();


### PR DESCRIPTION
STAR leaks memory when used within Orbit (https://github.com/10xGenomics/orbit).