### PR TITLE
Fix warnings and treat warnings as errors

### DIFF
--- a/source/ErrorWarning.cpp
+++ b/source/ErrorWarning.cpp
@@ -4,7 +4,7 @@
 #include "ErrorWarning.h"
 #include "TimeFunctions.h"
 
-void exitWithError(string messageOut, ostream &streamOut1, ostream &streamOut2, int errorInt, const Parameters &P) {
+void exitWithError(string messageOut, ostream &streamOut1, ostream &streamOut2, int errorInt, const Parameters &/*P*/) {
     time_t timeCurrent;
     time( &timeCurrent);
     if (streamOut1.good()) {
@@ -17,7 +17,7 @@ void exitWithError(string messageOut, ostream &streamOut1, ostream &streamOut2, 
     exit(errorInt);
 };
 
-void warningMessage(string messageOut, ostream &streamOut1, ostream &streamOut2, const Parameters &P) {
+void warningMessage(string messageOut, ostream &streamOut1, ostream &streamOut2, const Parameters &/*P*/) {
     time_t timeCurrent;
     time( &timeCurrent);
     if (streamOut1.good()) {

--- a/source/Makefile
+++ b/source/Makefile
@@ -18,7 +18,7 @@ ifeq ($(UNAME), Darwin)
 else
 	CXXFLAGS_extra :=
 endif
-CXXFLAGS_common := -pipe -std=c++11 -Wall -Wextra -fPIC $(CXXFLAGS_extra) $(COMPTIMEPLACE)
+CXXFLAGS_common := -pipe -std=c++11 -Wall -Wextra -Werror -fPIC $(CXXFLAGS_extra) $(COMPTIMEPLACE)
 
 CXXFLAGS_main := -O3 -g $(CXXFLAGS_common)
 CXXFLAGS_gdb :=  -O0 -g $(CXXFLAGS_common)

--- a/source/SuffixArrayFuns.cpp
+++ b/source/SuffixArrayFuns.cpp
@@ -15,7 +15,7 @@ uint compareSeqToGenome(const Genome &mapGen, char** s2, uint S, uint N, uint L,
      * dirR forward or reverse direction search on read sequence
      */
 
-    register int64 ii;
+    int64 ii;
 
     uint SAstr=mapGen.SA[iSA];
     bool dirG = (SAstr>>mapGen.GstrandBit) == 0; //forward or reverse strand of the genome
@@ -231,7 +231,7 @@ uint compareSeqToGenome1(const Genome &mapGen, char** s2, uint S, uint N, uint L
 
     //TODO no need for complementary sequence
 
-    register int64 ii;
+    int64 ii;
 
     uint SAstr=mapGen.SA[iSA];
     bool dirG = (SAstr>>mapGen.GstrandBit) == 0; //forward or reverse strand of the genome
@@ -356,13 +356,13 @@ uint funCalcSAiFromSA(char* gSeq, PackedArray& gSA, const Genome &mapGen, uint i
     bool dirG = (SAstr>>mapGen.GstrandBit) == 0; //forward or reverse strand of the genome
     SAstr &= mapGen.GstrandMask;
     iL4=-1;
-    register uint saind=0;
+    uint saind=0;
     if (dirG)
     {
-        register uint128 g1=*( (uint128*) (gSeq+SAstr) );
+        uint128 g1=*( (uint128*) (gSeq+SAstr) );
         for (int ii=0; ii<L; ii++)
         {
-            register char g2=(char) g1;
+            char g2=(char) g1;
             if (g2>3)
             {
                 iL4=ii;
@@ -376,10 +376,10 @@ uint funCalcSAiFromSA(char* gSeq, PackedArray& gSA, const Genome &mapGen, uint i
         return saind;
     } else
     {
-        register uint128 g1=*( (uint128*) (gSeq+mapGen.nGenome-SAstr-16) );
+        uint128 g1=*( (uint128*) (gSeq+mapGen.nGenome-SAstr-16) );
         for (int ii=0; ii<L; ii++)
         {
-            register char g2=(char) (g1>>(8*(15-ii)));
+            char g2=(char) (g1>>(8*(15-ii)));
             if (g2>3)
             {
                 iL4=ii;

--- a/source/Transcriptome_quantAlign.cpp
+++ b/source/Transcriptome_quantAlign.cpp
@@ -89,7 +89,7 @@ int alignToTranscript(Transcript &aG, uint trS1, uint8 trStr1, uint32 *exSE1, ui
     return 0; //this should not happen
 };
 
-uint32 Transcriptome::quantAlign (Transcript &aG, Transcript *aTall, vector<uint32> &readTranscripts, set<uint32> &readTrGenes) {
+uint32 Transcriptome::quantAlign (Transcript &aG, Transcript *aTall, vector<uint32> &/*readTranscripts*/, set<uint32> &/*readTrGenes*/) {
     uint32 nAtr=0; //number of alignments to the transcriptome
 
     //binary search through transcript starts

--- a/source/readLoad.cpp
+++ b/source/readLoad.cpp
@@ -1,7 +1,7 @@
 #include "readLoad.h"
 #include "ErrorWarning.h"
 
-int readLoad(istream& readInStream, const Parameters& P, uint iMate, uint& Lread, uint& LreadOriginal, char* readName, char* Seq, char* SeqNum, char* Qual, char* QualNum, uint &clip3pNtotal, uint &clip5pNtotal, uint &clip3pAdapterN, uint &iReadAll, uint &readFilesIndex, char &readFilter, string &readNameExtra){
+int readLoad(istream& readInStream, const Parameters& P, uint iMate, uint& Lread, uint& LreadOriginal, char* readName, char* Seq, char* SeqNum, char* Qual, char* QualNum, uint &clip3pNtotal, uint &clip5pNtotal, uint &clip3pAdapterN, uint &/*iReadAll*/, uint &/*readFilesIndex*/, char &/*readFilter*/, string &readNameExtra){
     //load one read from a stream
     int readFileType=0;
 


### PR DESCRIPTION
Add `-Werror` to `CXXFLAGS`.
Remove `register` keyword.
Comment out unused function arguments.